### PR TITLE
Action thinks 'secrets' isn't a thing.

### DIFF
--- a/.github/workflows/ansiblegalaxy.yml
+++ b/.github/workflows/ansiblegalaxy.yml
@@ -27,6 +27,6 @@ jobs:
       run: ansible --version
 
     - name: Deploy the collection
-      uses: artis3n/ansible_galaxy_collection@v1.0.0
+      uses: artis3n/ansible_galaxy_collection@v1.0.1
       with:
         api_key: ${{ secrets.GALAXY_API_KEY }}


### PR DESCRIPTION
This usage matches the documentation exactly...
https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables